### PR TITLE
Fixed 3d plotting and redundancy warning

### DIFF
--- a/moleview/src/draw.py
+++ b/moleview/src/draw.py
@@ -93,7 +93,7 @@ class DrawComplex:
 
         """
         self.fig = plt.figure()
-        self.ax = Axes3D(self.fig)
+        self.ax = self.fig.add_subplot(projection='3d')
 
         self.ax.set_title("Full complex", fontsize="12")
         # ax = fig.add_subplot(111, projection='3d')

--- a/moleview/src/draw.py
+++ b/moleview/src/draw.py
@@ -152,7 +152,7 @@ class DrawComplex:
         for i in range(len(self.atoms_pair)):
             merge = list(zip(self.atoms_pair[i][0], self.atoms_pair[i][1]))
             x, y, z = merge
-            self.ax.plot(x, y, z, "k-", color="black", linewidth=2)
+            self.ax.plot(x, y, z, color="black", linewidth=2)
 
     def add_legend(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="moleview", # Replace with your own username
-    version="1.1",
+    version="1.2",
     author="Rangsiman Ketkaew",
     author_email="rangsiman1993@gmail.com",
     description="MoleView: view your molecule anywhere and anytime.",


### PR DESCRIPTION
Hi!

The package currently has issues plotting 3d images because of the `self.ax = Axes3D(self.fig)` in the [draw.py](https://github.com/moleview/moleview/blob/master/moleview/src/draw.py) file. It displays an empty 2d plot instead of the expected 3d scatter plot. At some point during the development of matplotlib, the way to define 3d scatter plots changed to `fig.add_subplot(projection='3d')`, which is what needs to be changed in order to obtain the desired 3d plots of molecular xyz data. I've also deleted the "-k" parameter, which only generated a warning and was ignored.

Additionally, I've looked into the poor fps performance of matplotlib when plotting the scatter plots of molecules, but there aren't any really interesting choices other than changing the use of matplotlib for some other plotting package. There's not much room to use blitting in this case and switching backends or optimizing the edges doesn't seem to have much of an impact. All in all, matplotlib was not designed to prioritize plotting speed or interactiveness of 3d plots.